### PR TITLE
Swap paths in Sonarr configuration

### DIFF
--- a/cluster/apps/media/sonarr/ks.yaml
+++ b/cluster/apps/media/sonarr/ks.yaml
@@ -31,7 +31,7 @@ spec:
   dependsOn:
     - name: cluster-storage-longhorn
     - name: cluster-media-sonarr-base
-  path: ./cluster/apps/media/sonarr/app-4k
+  path: ./cluster/apps/media/sonarr/app
   prune: true
   sourceRef:
     kind: GitRepository
@@ -57,7 +57,7 @@ spec:
   dependsOn:
     - name: cluster-storage-longhorn
     - name: cluster-media-sonarr-base
-  path: ./cluster/apps/media/sonarr/app
+  path: ./cluster/apps/media/sonarr/app-4k
   prune: true
   sourceRef:
     kind: GitRepository


### PR DESCRIPTION
In cluster/apps/media/sonarr/ks.yaml, the Flux Kustomization names and their target paths appear inverted.

Currently:

26: name: cluster-media-sonarr
34: path: ./cluster/apps/media/sonarr/app-4k

and

52: name: cluster-media-sonarr-4k
60: path: ./cluster/apps/media/sonarr/app

This corrects.